### PR TITLE
Rely on commands to be in the $PATH

### DIFF
--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -8,7 +8,7 @@ namespace Phakebuilder;
 class Composer {
 
 	// Shorter form of --no-interaction
-	const DEFAULT_COMMAND = '/usr/bin/composer -n';
+	const DEFAULT_COMMAND = 'composer -n';
 
 	protected $command;
 

--- a/lib/Git.php
+++ b/lib/Git.php
@@ -7,7 +7,7 @@ namespace PhakeBuilder;
  */
 class Git {
 
-	const DEFAULT_COMMAND = '/usr/bin/git';
+	const DEFAULT_COMMAND = 'git';
 
 	protected $command;
 

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -7,7 +7,7 @@ namespace Phakebuilder;
  */
 class Service {
 
-	const DEFAULT_COMMAND = '/usr/sbin/service';
+	const DEFAULT_COMMAND = 'service';
 
 	protected $command;
 

--- a/lib/System.php
+++ b/lib/System.php
@@ -29,10 +29,10 @@ class System {
 			'DB_ADMIN_USER' => 'root',
 			'DB_ADMIN_PASS' => '',
 
-			'SYSTEM_COMMAND_MYSQL' => '/usr/bin/mysql',
-			'SYSTEM_COMMAND_MYSQL_REPLACE' => '/usr/bin/php vendor/interconnectit/search-replace-db/srdb.cli.php',
-			'SYSTEM_COMMAND_SERVICE' => '/usr/sbin/service',
-			'SYSTEM_COMMAND_SUDO' => '/usr/bin/sudo',
+			'SYSTEM_COMMAND_MYSQL' => 'mysql',
+			'SYSTEM_COMMAND_MYSQL_REPLACE' => 'php vendor/interconnectit/search-replace-db/srdb.cli.php',
+			'SYSTEM_COMMAND_SERVICE' => 'service',
+			'SYSTEM_COMMAND_SUDO' => 'sudo',
 		);
 
 		if (isset($defaults[$param])) {


### PR DESCRIPTION
Hardcoding paths to commands means that there is a lot of local
configuration on every environment which is different (not nice!).

The possible solution with /usr/bin/env doesn't work because it
doesn't allow to pass parameters like '/usr/bin/env composer -n',
at least on Linux.