### PR TITLE
Allow skipping 'git checkout' via empty GIT_BRANCH

### DIFF
--- a/lib/System.php
+++ b/lib/System.php
@@ -20,7 +20,7 @@ class System {
 			'PHAKE_BUILDER_LOG_LEVEL' => 'INFO',
 
 			'GIT_REMOTE' => 'origin',
-			'GIT_BRANCH' => 'master',
+			'GIT_BRANCH' => '',
 
 			'DB_HOST' => 'localhost',
 			'DB_USER' => 'root',

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -8,8 +8,8 @@ class SystemTest extends \PHPUnit_Framework_TestCase {
 
 	public function test_getDefaultValue() {
 		// Known value
-		$result = System::getDefaultValue('GIT_BRANCH');
-		$this->assertEquals('master', $result);
+		$result = System::getDefaultValue('GIT_REMOTE');
+		$this->assertEquals('origin', $result);
 
 		// Unknown value
 		$result = System::getDefaultValue('THIS_VALUE_WILL_NEVER_EXIST');


### PR DESCRIPTION
The functionality of the skip has been implemented before,
but it was impossible to trigger due to the population of
GIT_BRANCH via lib/System.php .

This should help with things like Travis CI tests for
non-master branchenon-master branchess