### PR TITLE
Utilize realpath() before rm/chmod/etc

### DIFF
--- a/src/PhakeBuilder/FileSystem.php
+++ b/src/PhakeBuilder/FileSystem.php
@@ -123,8 +123,15 @@ class FileSystem
      */
     public static function removePath($path)
     {
-        self::remove($path);
-        return true;
+        $result = false;
+
+        $path = realpath($path);
+        if ($path) {
+            self::remove($path);
+            $result = true;
+        }
+
+        return $result;
     }
 
     /**
@@ -140,6 +147,11 @@ class FileSystem
     public static function chmodPath($path, $dirMode = null, $fileMode = null, $recursive = true)
     {
         $result = false;
+
+        $path = realpath($path);
+        if (empty($path)) {
+            return false;
+        }
 
         $dirMode = $dirMode ?: self::getDefaultDirMode();
         $fileMode = $fileMode ?: self::getDefaultFileMode();
@@ -209,6 +221,11 @@ class FileSystem
      */
     public static function chownPath($path, $user = null, $recursive = true)
     {
+        $path = realpath($path);
+        if (empty($path)) {
+            return false;
+        }
+
         if (empty($user)) {
             $user = self::getDefaultUser();
         }
@@ -226,6 +243,11 @@ class FileSystem
      */
     public static function chgrpPath($path, $group = null, $recursive = true)
     {
+        $path = realpath($path);
+        if (empty($path)) {
+            return false;
+        }
+
         if (empty($group)) {
             $group = self::getDefaultGroup();
         }

--- a/tests/PhakeBuilder/FileSystemTest.php
+++ b/tests/PhakeBuilder/FileSystemTest.php
@@ -55,6 +55,12 @@ class FileSystemTest extends \PHPUnit_Framework_TestCase
         $this->assertFileNotExists($dstFile, "Failed to remove destination file [$dstFile]");
     }
 
+    public function testRemoveReal()
+    {
+        $result = \PhakeBuilder\FileSystem::removePath('/this-path-does-not-exist');
+        $this->assertFalse($result, "removePath() not bailing early when path is not real");
+    }
+
     public function testChmodDirectory()
     {
         $tmpDir = tempnam(sys_get_temp_dir(), 'phakeTest_');
@@ -93,6 +99,12 @@ class FileSystemTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('0775', $permissions, "Destination directory [$tmpDir] permissions [$permissions] are wrong");
 
         rmdir($tmpDir);
+    }
+
+    public function testChmodReal()
+    {
+        $result = \PhakeBuilder\FileSystem::chmodPath('/this-path-does-not-exist');
+        $this->assertFalse($result, "chmodPath() not bailing early when path is not real");
     }
 
     public function testChmodDirectoryRecursive()
@@ -176,6 +188,12 @@ class FileSystemTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testChownReal()
+    {
+        $result = \PhakeBuilder\FileSystem::chownPath('/this-path-does-not-exist');
+        $this->assertFalse($result, "chownPath() not bailing early when path is not real");
+    }
+
     /**
      * Test chgrp() operation
      *
@@ -194,6 +212,12 @@ class FileSystemTest extends \PHPUnit_Framework_TestCase
         if (file_exists($dst)) {
             rmdir($dst);
         }
+    }
+
+    public function testChgrpReal()
+    {
+        $result = \PhakeBuilder\FileSystem::chgrpPath('/this-path-does-not-exist');
+        $this->assertFalse($result, "chgrpPath() not bailing early when path is not real");
     }
 
     public function testDownloadFile()


### PR DESCRIPTION
phake-builder is involved in some potentially dangerous
and confusing operations, like removing paths and changing
permissions.  To help avoid isssues with that, it now
utilizes realpath() check before rm, chmod, chown, and chgrp.