### PR TITLE
Check for POSIX extension

### DIFF
--- a/src/PhakeBuilder/FileSystem.php
+++ b/src/PhakeBuilder/FileSystem.php
@@ -78,10 +78,15 @@ class FileSystem
      *
      * Return a fallback default for user (assumses owner of current process)
      *
+     * @throws \RuntimeException when php-posix is not installed
      * @return string
      */
     protected static function getDefaultUser()
     {
+        if (!extension_loaded('posix')) {
+            throw new \RuntimeException("PHP extension posix is not installed.");
+        }
+
         $processUser = posix_getpwuid(posix_geteuid());
         return $processUser['name'];
     }
@@ -91,10 +96,15 @@ class FileSystem
      *
      * Return a fallback default for group (assumses owner of current process)
      *
+     * @throws \RuntimeException when php-posix is not installed
      * @return string
      */
     protected static function getDefaultGroup()
     {
+        if (!extension_loaded('posix')) {
+            throw new \RuntimeException("PHP extension posix is not installed.");
+        }
+
         $processGroup = posix_getgrgid(posix_getegid());
         return $processGroup['name'];
     }

--- a/tests/PhakeBuilder/FileSystemTest.php
+++ b/tests/PhakeBuilder/FileSystemTest.php
@@ -177,6 +177,10 @@ class FileSystemTest extends \PHPUnit_Framework_TestCase
      */
     public function testChownPath()
     {
+        if (!extension_loaded('posix')) {
+            $this->markTestSkipped('The POSIX extension is not available');
+        }
+
         $dst = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phakeTest_owner';
         if (!file_exists($dst)) {
             mkdir($dst);
@@ -203,6 +207,10 @@ class FileSystemTest extends \PHPUnit_Framework_TestCase
      */
     public function testChgrpPath()
     {
+        if (!extension_loaded('posix')) {
+            $this->markTestSkipped('The POSIX extension is not available');
+        }
+
         $dst = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phakeTest_owner';
         if (!file_exists($dst)) {
             mkdir($dst);

--- a/tests/PhakeBuilder/SystemTest.php
+++ b/tests/PhakeBuilder/SystemTest.php
@@ -19,6 +19,9 @@ class SystemTest extends \PHPUnit_Framework_TestCase
 
     public function testNeedsSudo()
     {
+        if (!extension_loaded('posix')) {
+            $this->markTestSkipped('The POSIX extension is not available');
+        }
         $uid = posix_getuid();
         $result = System::needsSudo();
         $expected = ($uid == 0) ? false : true;


### PR DESCRIPTION
POSIX extension is not always installed.  If it's not there, some
of the filesystem tasks can throw fatal errors about posix
functions being unknown.  The user needs either either provide all
necessary paramenters (to avoid guessing for current user and group)
or install the php-posix extension.

This commit checks whether or not the posix-extension is installed
before calling the posix_* functions.  This is a better solution than
doing this check in composer, as there is plenty of phake-builder
functionality that can be useful without the filesystem bits.