### PR TITLE
Use \PhakeBuilder\Utils::getCurrentDir() for paths (task #121)

### DIFF
--- a/src/PhakeBuilder/Utils.php
+++ b/src/PhakeBuilder/Utils.php
@@ -59,4 +59,24 @@ class Utils
 
         return $result;
     }
+
+    /**
+     * Get current working directory
+     *
+     * @param bool $addTrailingSep Whether or not add trailing directory separator
+     * @return string
+     */
+    public static function getCurrentDir($addTrailingSep = true)
+    {
+        $result = getcwd();
+        if (empty($result)) {
+            $result = '.';
+        }
+
+        if ($addTrailingSep) {
+            $result .= DIRECTORY_SEPARATOR;
+        }
+
+        return $result;
+    }
 }

--- a/src/Phakefiles/Archive.php
+++ b/src/Phakefiles/Archive.php
@@ -7,8 +7,8 @@ group('archive', function () {
         printSeparator();
         printInfo("Task: archive:extract (Extract ZIP or TAR archive)");
 
-        $src = requireValue('EXTRACT_SRC', $app);
-        $dst = requireValue('EXTRACT_DST', $app);
+        $src = \PhakeBuilder\Utils::getCurrentDir() . requireValue('EXTRACT_SRC', $app);
+        $dst = \PhakeBuilder\Utils::getCurrentDir() . requireValue('EXTRACT_DST', $app);
 
         try {
             \PhakeBuilder\Archive::extract($src, $dst);
@@ -23,8 +23,8 @@ group('archive', function () {
         printSeparator();
         printInfo("Task: archive:compress (Create ZIP or TAR archive)");
 
-        $src = requireValue('COMPRESS_SRC', $app);
-        $dst = requireValue('COMPRESS_DST', $app);
+        $src = \PhakeBuilder\Utils::getCurrentDir() . requireValue('COMPRESS_SRC', $app);
+        $dst = \PhakeBuilder\Utils::getCurrentDir() . requireValue('COMPRESS_DST', $app);
 
         try {
             \PhakeBuilder\Archive::compress($src, $dst);

--- a/src/Phakefiles/Build.php
+++ b/src/Phakefiles/Build.php
@@ -11,9 +11,9 @@ if (!function_exists('phakeGetBuildDirs')) {
     function phakeGetBuildDirs()
     {
         $result = array(
-            'build/coverage',
-            'build/logs',
-            'build/pdepend',
+            \PhakeBuilder\Utils::getCurrentDir() . 'build/coverage',
+            \PhakeBuilder\Utils::getCurrentDir() . 'build/logs',
+            \PhakeBuilder\Utils::getCurrentDir() . 'build/pdepend',
         );
 
         return $result;

--- a/src/Phakefiles/Builder.php
+++ b/src/Phakefiles/Builder.php
@@ -282,7 +282,7 @@ group('builder', function () {
     task('init', function ($app) {
         $hasDotEnv = false;
         try {
-            Dotenv::load(getcwd());
+            Dotenv::load(\PhakeBuilder\Utils::getCurrentDir());
             $hasDotEnv = true;
         } catch (Exception $e) {
             $hasDotEnv = false;

--- a/src/Phakefiles/Dotenv.php
+++ b/src/Phakefiles/Dotenv.php
@@ -7,8 +7,8 @@ group('dotenv', function () {
         printSeparator();
         printInfo("Task: dotenv:create (Create .env file)");
 
-        $envFile = getcwd() . DIRECTORY_SEPARATOR . '.env';
-        $templateFile = getcwd() . DIRECTORY_SEPARATOR . '.env.example';
+        $envFile = \PhakeBuilder\Utils::getCurrentDir() . '.env';
+        $templateFile = \PhakeBuilder\Utils::getCurrentDir() . '.env.example';
 
         if (!file_exists($templateFile)) {
             throw new \RuntimeException(".env template file ($templateFile) does not exist");
@@ -74,7 +74,7 @@ group('dotenv', function () {
         printInfo("Task: dotenv:reload (Reload settings from .env file)");
 
         Dotenv::makeMutable();
-        Dotenv::load(getcwd());
+        Dotenv::load(\PhakeBuilder\Utils::getCurrentDir());
         Dotenv::makeImmutable();
 
         printSuccess("SUCCESS!");
@@ -85,7 +85,7 @@ group('dotenv', function () {
         printSeparator();
         printInfo("Task: dotenv:delete (Delete .env file)");
 
-        $envFile = getcwd() . DIRECTORY_SEPARATOR . '.env';
+        $envFile = \PhakeBuilder\Utils::getCurrentDir() . '.env';
         if (file_exists($envFile)) {
             $result = unlink($envFile);
             if ($result) {

--- a/src/Phakefiles/File.php
+++ b/src/Phakefiles/File.php
@@ -7,8 +7,8 @@ group('file', function () {
         printSeparator();
         printInfo("Task: file:process (Processing template file)");
 
-        $src = requireValue('TEMPLATE_SRC', $app);
-        $dst = requireValue('TEMPLATE_DST', $app);
+        $src = \PhakeBuilder\Utils::getCurrentDir() . requireValue('TEMPLATE_SRC', $app);
+        $dst = \PhakeBuilder\Utils::getCurrentDir() . requireValue('TEMPLATE_DST', $app);
 
         $template = new \PhakeBuilder\Template($src);
         $placeholders = $template->getPlaceholders();
@@ -33,7 +33,7 @@ group('file', function () {
         printSeparator();
         printInfo("Task: file:touch (Create empty file or update timestamp of existing)");
 
-        $file = requireValue('TOUCH_PATH', $app);
+        $file = \PhakeBuilder\Utils::getCurrentDir() . requireValue('TOUCH_PATH', $app);
         $result = touch($file);
         if (!$result) {
             throw new \RuntimeException("Failed to touch file");
@@ -46,8 +46,8 @@ group('file', function () {
         printSeparator();
         printInfo("Task: file:link (Create symlink link)");
 
-        $src = requireValue('LINK_SRC', $app);
-        $dst = requireValue('LINK_DST', $app);
+        $src = \PhakeBuilder\Utils::getCurrentDir() . requireValue('LINK_SRC', $app);
+        $dst = \PhakeBuilder\Utils::getCurrentDir() . requireValue('LINK_DST', $app);
         $result = symlink($src, $dst);
         if (!$result) {
             throw new \RuntimeException("Failed to create symbolic link");
@@ -60,8 +60,8 @@ group('file', function () {
         printSeparator();
         printInfo("Task: file:mv (Rename file or folder)");
 
-        $src = requireValue('MV_SRC', $app);
-        $dst = requireValue('MV_DST', $app);
+        $src = \PhakeBuilder\Utils::getCurrentDir() . requireValue('MV_SRC', $app);
+        $dst = \PhakeBuilder\Utils::getCurrentDir() . requireValue('MV_DST', $app);
         $result = rename($src, $dst);
         if (!$result) {
             throw new \RuntimeException("Failed to rename file or folder");
@@ -74,7 +74,7 @@ group('file', function () {
         printSeparator();
         printInfo("Task: file:rm (Recursively remove file or folder)");
 
-        $path = requireValue('RM_PATH', $app);
+        $path = \PhakeBuilder\Utils::getCurrentDir() . requireValue('RM_PATH', $app);
         $result = \PhakeBuilder\FileSystem::removePath($path);
         if (!$result) {
             throw new \RuntimeException("Failed to remove path");
@@ -87,7 +87,7 @@ group('file', function () {
         printSeparator();
         printInfo("Task: file:mkdir (Create folder)");
 
-        $path = requireValue('MKDIR_PATH', $app);
+        $path = \PhakeBuilder\Utils::getCurrentDir() . requireValue('MKDIR_PATH', $app);
         $mode = getValue('MKDIR_MODE', $app);
         $result = \PhakeBuilder\FileSystem::makeDir($path, $mode);
         if (!$result) {
@@ -101,7 +101,7 @@ group('file', function () {
         printSeparator();
         printInfo("Task: file:chmod (Change permissions on path)");
 
-        $path = requireValue('CHMOD_PATH', $app);
+        $path = \PhakeBuilder\Utils::getCurrentDir() . requireValue('CHMOD_PATH', $app);
         $dirMode = getValue('CHMOD_DIR_MODE', $app);
         $fileMode = getValue('CHMOD_FILE_MODE', $app);
         $result = \PhakeBuilder\FileSystem::chmodPath($path, $dirMode, $fileMode);
@@ -116,7 +116,7 @@ group('file', function () {
         printSeparator();
         printInfo("Task: file:chown (Change user ownership on path)");
 
-        $path = requireValue('CHOWN_PATH', $app);
+        $path = \PhakeBuilder\Utils::getCurrentDir() . requireValue('CHOWN_PATH', $app);
         $user = getValue('CHOWN_USER', $app);
         $result = \PhakeBuilder\FileSystem::chownPath($path, $user);
         if (!$result) {
@@ -130,7 +130,7 @@ group('file', function () {
         printSeparator();
         printInfo("Task: file:chgrp (Change group ownership on path)");
 
-        $path = requireValue('CHGRP_PATH', $app);
+        $path = \PhakeBuilder\Utils::getCurrentDir() . requireValue('CHGRP_PATH', $app);
         $group = getValue('CHGRP_GROUP', $app);
         $result = \PhakeBuilder\FileSystem::chgrpPath($path, $group);
         if (!$result) {
@@ -145,7 +145,7 @@ group('file', function () {
         printInfo("Task: file:download (Download file from URL)");
 
         $src = requireValue('DOWNLOAD_SRC', $app);
-        $dst = requireValue('DOWNLOAD_DST', $app);
+        $dst = \PhakeBuilder\Utils::getCurrentDir() . requireValue('DOWNLOAD_DST', $app);
         $result = \PhakeBuilder\FileSystem::downloadFile($src, $dst);
         if (!$result) {
             throw new \RuntimeException("Failed to download file");

--- a/src/Phakefiles/Mysql.php
+++ b/src/Phakefiles/Mysql.php
@@ -71,7 +71,7 @@ group('mysql', function () {
 
         $mysql = new \PhakeBuilder\MySQL(requireValue('SYSTEM_COMMAND_MYSQL', $app));
         $mysql->setDSN($dsn);
-        $command = $mysql->import(requireValue('DB_DUMP_PATH', $app));
+        $command = $mysql->import(\PhakeBuilder\Utils::getCurrentDir() . requireValue('DB_DUMP_PATH', $app));
         $secureStrings = array('DB_PASS', 'DB_ADMIN_PASS');
         doShellCommand($command, $secureStrings);
     });

--- a/tests/PhakeBuilder/UtilsTest.php
+++ b/tests/PhakeBuilder/UtilsTest.php
@@ -19,4 +19,17 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_array($result), 'List of found Phakefiles is not an array');
         $this->assertFalse(empty($result), 'No Phakefiles found');
     }
+
+    public function testGetCurrentDir()
+    {
+        $cwdNoTrail = \PhakeBuilder\Utils::getCurrentDir(false);
+        $this->assertTrue(is_string($cwdNoTrail), "getCurrentDir() returned a non-string for no trail");
+        $this->assertFalse(empty($cwdNoTrail), "getCurrentDir() returned empty result for no trail");
+
+        $cwdWithTrail = \PhakeBuilder\Utils::getCurrentDir();
+        $this->assertTrue(is_string($cwdWithTrail), "getCurrentDir() returned a non-string for trail");
+        $this->assertFalse(empty($cwdWithTrail), "getCurrentDir() returned empty result for trail");
+
+        $this->assertEquals($cwdWithTrail, $cwdNoTrail . DIRECTORY_SEPARATOR, "getCurrentDir() trail/no-trail is broken");
+    }
 }


### PR DESCRIPTION
The `realpath()` requires an existing path or it will return
null.  Since we use relative paths sometimes, it's better to
prepend them with the current directory path.