### PR TITLE
Removed system defaults from `.env` file (task #4189)

### DIFF
--- a/src/Phakefiles/Dotenv.php
+++ b/src/Phakefiles/Dotenv.php
@@ -16,11 +16,9 @@ group('dotenv', function () {
         foreach ($app as $key => $value) {
             $appParams[$key] = $value;
         }
-        // System defaults
-        $defaults = \PhakeBuilder\System::getDefaultValue();
 
         $dotenv = new \PhakeBuilder\Dotenv();
-        $result = $dotenv->generate($envFile, $templateFile, $appParams, $defaults);
+        $result = $dotenv->generate($envFile, $templateFile, $appParams);
 
         if (!$result) {
             throw new \RuntimeException("Failed to save $envFile");


### PR DESCRIPTION
There is no need to add system default values to the resulting
`.env` file, as phake-builder already knows how to get those
values.