### PR TITLE
Replace interconnectit/search-replace-db with Qobo fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"pyrech/composer-changelogs": "~1.4",
 		"jaz303/phake": "~0.6",
 		"vlucas/phpdotenv": "~1.1",
-		"interconnectit/search-replace-db": "3.1",
+		"qobo/search-replace-db": "~4.0",
 		"qobo/pattern": "~1.0",
 		"monolog/monolog": "~1.11",
 		"kmelia/monolog-stdout-handler": "~1.2",


### PR DESCRIPTION
Changelogs summary:

 - interconnectit/search-replace-db removed (installed version was 3.1)

 - qobo/search-replace-db installed in version v4.0.0
   Release notes: https://github.com/QoboLtd/Search-Replace-DB/releases/tag/v4.0.0